### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/python-poetry-java8.yml
+++ b/.github/workflows/python-poetry-java8.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Code checkout
       uses: actions/checkout@master
     - name: Publish python-poetry-java8 to docker hub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
         # https://github.com/marketplace/actions/publish-docker
       with:
         name: mattjwnet/python-poetry-java8


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore